### PR TITLE
fix: cache tile exceptions

### DIFF
--- a/src/aws/osml/photogrammetry/digital_elevation_model.py
+++ b/src/aws/osml/photogrammetry/digital_elevation_model.py
@@ -161,7 +161,10 @@ class DigitalElevationModel(ElevationModel):
 
         :return: the cached interpolation object, sensor model, and summary
         """
-        elevations_array, sensor_model, summary = self.tile_factory.get_tile(tile_path)
+        try:
+            elevations_array, sensor_model, summary = self.tile_factory.get_tile(tile_path)
+        except Exception:
+            elevations_array, sensor_model, summary = (None, None, None)
         if elevations_array is not None and sensor_model is not None:
             height, width = elevations_array.shape
             x = range(0, width)

--- a/test/aws/osml/photogrammetry/test_digital_elevation_model.py
+++ b/test/aws/osml/photogrammetry/test_digital_elevation_model.py
@@ -111,6 +111,29 @@ class TestDigitalElevationModel(unittest.TestCase):
         assert mock_tile_set.find_tile_id.call_count == 1
         assert mock_tile_factory.get_tile.call_count == 1
 
+    def test_tile_exception(self):
+        from aws.osml.photogrammetry.coordinates import GeodeticWorldCoordinate
+        from aws.osml.photogrammetry.digital_elevation_model import (
+            DigitalElevationModel,
+            DigitalElevationModelTileFactory,
+            DigitalElevationModelTileSet,
+        )
+
+        # This is the case when the tile factory has an exception
+        mock_tile_set = mock.Mock(DigitalElevationModelTileSet)
+        mock_tile_set.find_tile_id.return_value = "MockN00E000V0.tif"
+        mock_tile_factory = mock.Mock(DigitalElevationModelTileFactory)
+        mock_tile_factory.get_tile.side_effect = Exception
+
+        dem = DigitalElevationModel(mock_tile_set, mock_tile_factory)
+
+        world_coordinate = GeodeticWorldCoordinate([1.0, 2.0, 0.0])
+        assert not dem.set_elevation(world_coordinate)
+        assert not dem.set_elevation(world_coordinate)
+        assert world_coordinate.elevation == 0.0
+        assert mock_tile_set.find_tile_id.call_count == 2
+        assert mock_tile_factory.get_tile.call_count == 1
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Exception handling has been added to the `DigitalElevationModel`'s `get_interpolation_grid` method. The tile factory may throw an exception when accessing a tile (such as it is missing or there is a network error for remote files); handling this case in the `get_interpolation_grid` method allows for caching `None, None, None` as the return value. This is important for cases like network error, where repeated access attempts from a `SensorModel` can lead to significant slowdown.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
