### PR TITLE
fix: optional elevation summary in DEM RRDot surface projection

### DIFF
--- a/test/aws/osml/photogrammetry/test_sicd_sensor_model.py
+++ b/test/aws/osml/photogrammetry/test_sicd_sensor_model.py
@@ -1,4 +1,5 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
 
 import unittest
 from math import radians
@@ -100,6 +101,22 @@ class TestSICDSensorModel(unittest.TestCase):
         ecf_world_coordinate = geodetic_to_geocentric(geodetic_world_coordinate)
 
         assert np.allclose(ecf_world_coordinate.coordinate, scp_ecf.coordinate, atol=0.001)
+
+        # This second class is used to test missing elevation summary.
+        class EmptyElevationModel(TestElevationModel):
+            def describe_region(
+                self, world_coordinate: GeodeticWorldCoordinate
+            ) -> Optional[Tuple[float, float, float, float]]:
+                return None
+
+        regionless_ecf_world_coordinate = geodetic_to_geocentric(
+            sicd_sensor_model.image_to_world(
+                ImageCoordinate([sicd.image_data.scppixel.col, sicd.image_data.scppixel.row]),
+                elevation_model=EmptyElevationModel(scp_lle.elevation),
+            )
+        )
+
+        assert np.allclose(ecf_world_coordinate.coordinate, regionless_ecf_world_coordinate.coordinate, atol=0.001)
 
         geo_scp_world_coordinate = GeodeticWorldCoordinate(
             [radians(sicd.geo_data.scp.llh.lon), radians(sicd.geo_data.scp.llh.lat), sicd.geo_data.scp.llh.hae]


### PR DESCRIPTION
The `SICDSensorModel` requires that an elevation model, if supplied, implement `describe_region` to provide a summary of the area surrounding a point. `ElevationModel` itself indicates an optional return value for this method, though every implemented elevation model in the toolkit provides a summary.

One option is to handle no summary with defaults in the caller, which has been added by this PR. `DEMRRDotSurfaceProjection` has additional initialization parameters for min/max height and spacing. The `SICDSensorModel` will override these will elevation summary information, if available.

Another option is to require implementation of `describe_region` and have every elevation model create defaults. This is the current behavior of the `ConstantElevationModel`.

### Notes

Defaults were roughly chosen to match:
  - min height: Denman Glacier's canyon
  - max height: Mount Everest
  - post spacing: same default as `ConstantElevationModel`

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [x] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
