### PR TITLE
fix: add SIDD side of track

### DIFF
--- a/src/aws/osml/gdal/sidd_sensor_model_builder.py
+++ b/src/aws/osml/gdal/sidd_sensor_model_builder.py
@@ -1,4 +1,5 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
 
 import logging
 from typing import Optional, Union
@@ -97,12 +98,26 @@ class SIDDSensorModelBuilder(SensorModelBuilder):
             arp_poly=arp_poly,
         )
 
+        center_time = projection_set.coa_time_poly(0, 0)
+        side_of_track = SICDSensorModel.compute_side_of_track(
+            scp_ecf=scp_ecf,
+            scp_arp=projection_set.arp_poly(center_time),
+            scp_varp=projection_set.varp_poly(center_time),
+        )
+        u_spn = SICDSensorModel.compute_u_spn(
+            scp_ecf=scp_ecf,
+            scp_arp=projection_set.arp_poly(center_time),
+            scp_varp=projection_set.varp_poly(center_time),
+            side_of_track=side_of_track,
+        )
+
         u_gpn = SICDSensorModel.compute_u_gpn(scp_ecf=scp_ecf, u_row=u_row, u_col=u_col)
 
         sidd_sensor_model = SICDSensorModel(
             coord_converter=coord_converter,
             coa_projection_set=projection_set,
-            u_spn=u_gpn,
+            u_spn=u_spn,
+            side_of_track=side_of_track,
             u_gpn=u_gpn,
         )
 

--- a/src/aws/osml/photogrammetry/sicd_sensor_model.py
+++ b/src/aws/osml/photogrammetry/sicd_sensor_model.py
@@ -1,4 +1,5 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
 
 import logging
 from abc import abstractmethod
@@ -1000,6 +1001,34 @@ class SICDSensorModel(SensorModel):
         self.default_surface_projection = GroundPlaneRRDotSurfaceProjection(self.coord_converter.scp_ecf, self.uvect_gpn)
 
     @staticmethod
+    def compute_side_of_track(scp_ecf: WorldCoordinate, scp_arp: np.ndarray, scp_varp: np.ndarray) -> str:
+        """
+        This helper function computes side of track through partially calculating squint angle.
+        For squint angle reference, see Volume 1 of the SIDD Specification.
+
+        :param scp_ecf: Scene Center Point position in ECF coordinates
+        :param scp_arp: aperture reference point position
+        :param scp_varp: aperture reference point velocity
+        :return: either 'R' for right or 'L' for left
+        """
+        # Get the unit normal (UP) at ARP.
+        up = scp_arp / np.linalg.norm(scp_arp)
+        # Get the LOS vector from ARP to SCP.
+        los = scp_ecf.coordinate - scp_arp
+        # To lie in the ENU plane centered at ARP, remove the U portion.
+        los -= np.dot(los, up) * up
+        los /= np.linalg.norm(los)
+        # Also put velocity in the plane.
+        scp_varp -= np.dot(scp_varp, up) * up
+        scp_varp /= np.linalg.norm(scp_varp)
+        # The cross product from velocity to los will align UP if pointing left.
+        xprod = np.cross(scp_varp, los)
+        xprod /= np.linalg.norm(xprod)
+        if np.dot(xprod, up) >= 0:
+            return "L"
+        return "R"
+
+    @staticmethod
     def compute_u_spn(scp_ecf: WorldCoordinate, scp_arp: np.ndarray, scp_varp: np.ndarray, side_of_track: str) -> np.ndarray:
         """
         This helper function computes the slant plane normal.
@@ -1086,6 +1115,7 @@ class SICDSensorModel(SensorModel):
         # (3) Set initial ground plane position G1 to the scene point position S.
         scene_point = np.array([ecf_world_coordinate.x, ecf_world_coordinate.y, ecf_world_coordinate.z])
         g_n = scene_point.copy()
+        local_surface_projection = GroundPlaneRRDotSurfaceProjection(WorldCoordinate(scene_point), self.uvect_gpn)
 
         xrow_ycol_n = None
         cont = True
@@ -1106,7 +1136,7 @@ class SICDSensorModel(SensorModel):
             r_tgt_coa, r_dot_tgt_coa, time_coa, arp_coa, varp_coa = self.coa_projection_set.precise_rrdot_computation(
                 xrow_ycol_n
             )
-            p_n = self.default_surface_projection.rrdot_to_ground(r_tgt_coa, r_dot_tgt_coa, arp_coa, varp_coa)
+            p_n = local_surface_projection.rrdot_to_ground(r_tgt_coa, r_dot_tgt_coa, arp_coa, varp_coa)
 
             # (6) Compute the displacement between ground plane point Pn and the scene point S.
             diff_n = scene_point - p_n[0]


### PR DESCRIPTION
The `SIDDSensorModelBuilder` was not passing `side_of_track` or `u_spn` to the `SICDSensorModel`. This results in a model that only handles left / "L" and messes up the relationship with the image plane. The `SICDSensorModel` update step in `world_to_image` was also not using a projection that necessarily contains the scene point, which causes the method to exit on max iterations without converging.

First, a calculation method for `side_of_track` was added that uses the orientation of a cross product. It was determined that this method would be more robust than relying on sign of some of the other parameters. With `side_of_track`, `u_spn` could be calculated instead of setting it to `u_gpn`. The `SICDSensorModel` update step was changed to use a local projection.

### Notes

These changes still require new tests / updates to sample test files. One of the old tests now fails - it relies on approximate corner points in the file equating to the true solve.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [x] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [ ] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
