### PR TITLE
feat: add defaulted sensor model

### DIFF
--- a/src/aws/osml/photogrammetry/__init__.py
+++ b/src/aws/osml/photogrammetry/__init__.py
@@ -118,6 +118,7 @@ from .coordinates import (
     geocentric_to_geodetic,
     geodetic_to_geocentric,
 )
+from .defaulted_sensor_model import DefaultedSensorModel
 from .digital_elevation_model import DigitalElevationModel, DigitalElevationModelTileFactory, DigitalElevationModelTileSet
 from .elevation_model import ConstantElevationModel, ElevationModel, ElevationRegionSummary
 from .elevation_offset_provider import ConstantOffsetProvider, ElevationOffsetProvider

--- a/src/aws/osml/photogrammetry/defaulted_sensor_model.py
+++ b/src/aws/osml/photogrammetry/defaulted_sensor_model.py
@@ -1,0 +1,86 @@
+#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
+
+import math
+from typing import Any, Dict, Optional
+
+from .coordinates import GeodeticWorldCoordinate, ImageCoordinate
+from .elevation_model import ElevationModel
+from .sensor_model import SensorModel, SensorModelOptions
+
+
+class DefaultedSensorModel(SensorModel):
+    """
+    Sensor model wrapper that adds default options for image_to_world.
+    """
+
+    def __init__(
+        self,
+        inner_sensor_model: SensorModel,
+        elevation_model: Optional[ElevationModel] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """
+        Create the defaulted model using an inner sensor model and defaults for the elevation model and options
+        dictionary.
+
+        :param inner_sensor_model: inner model that actually does calculations
+        :param elevation_model: default elevation model for the sensor model
+        :param options: default options dictionary for the sensor model
+
+        :return: None
+        """
+        self.inner_sensor_model = inner_sensor_model
+        self.elevation_model = elevation_model
+        self.options = options
+
+    def image_to_world(
+        self,
+        image_coordinate: ImageCoordinate,
+        elevation_model: Optional[ElevationModel] = None,
+        options: Optional[Dict[str, Any]] = None,
+    ) -> GeodeticWorldCoordinate:
+        """
+        This function returns the longitude, latitude, elevation world coordinate associated with the x, y coordinate
+        of any pixel in the full image.
+
+        :param image_coordinate: the x, y full image coordinate
+        :param elevation_model: optional elevation model used to transform the coordinate
+        :param options: optional dictionary of hints, passed to nested sensor models
+
+        :return: the longitude, latitude, elevation world coordinate
+        """
+        if options is None:
+            new_options = self.options
+        elif self.options is None:
+            new_options = options
+        else:
+            new_options = {**self.options, **options}
+        ignore_default_elevation_model = new_options.get(
+            SensorModelOptions.IGNORE_DEFAULT_ELEVATION_MODEL,
+            False,
+        )
+        return self.inner_sensor_model.image_to_world(
+            image_coordinate,
+            self.elevation_model if elevation_model is None and not ignore_default_elevation_model else elevation_model,
+            new_options,
+        )
+
+    def world_to_image(
+        self,
+        world_coordinate: GeodeticWorldCoordinate,
+    ) -> ImageCoordinate:
+        """
+        This function returns the x, y full image coordinate associated with a given longitude, latitude, elevation
+        world coordinate. If elevation is NaN, it will be set by the default elevation model if it exists or become 0.
+
+        :param world_coordinate: the longitude, latitude, elevation world coordinate
+
+        :return: the x, y full image coordinate
+        """
+        if math.isnan(world_coordinate.elevation):
+            new_world_coordinate = GeodeticWorldCoordinate(world_coordinate.coordinate)
+            new_world_coordinate.elevation = 0.0
+            if self.elevation_model is not None:
+                self.elevation_model.set_elevation(new_world_coordinate)
+            return self.inner_sensor_model.world_to_image(new_world_coordinate)
+        return self.inner_sensor_model.world_to_image(world_coordinate)

--- a/src/aws/osml/photogrammetry/sensor_model.py
+++ b/src/aws/osml/photogrammetry/sensor_model.py
@@ -1,4 +1,5 @@
 #  Copyright 2023-2024 Amazon.com, Inc. or its affiliates.
+#  Copyright 2025-2025 General Atomics Integrated Intelligence, Inc.
 
 import logging
 from abc import ABC, abstractmethod
@@ -60,3 +61,4 @@ class SensorModelOptions(str, Enum):
 
     INITIAL_GUESS = "initial_guess"
     INITIAL_SEARCH_DISTANCE = "initial_search_distance"
+    IGNORE_DEFAULT_ELEVATION_MODEL = "ignore_default_elevation_model"


### PR DESCRIPTION
A `DefaultedSensorModel` captures an elevation model and sensor model options on creation so the user does not have to supply them on every call to `image_to_world`. The default elevation model can also be used to auto populate elevation if not supplied in `world_to_image`. An extra sensor model option is required to force `None`, if desired, in the `image_to_world` call if a default elevation model has already been set.

### Notes

This code needs testing. It is currently up for discussion purposes.

The diagram will need updating.

### Checklist

Before you submit a pull request, please make sure you have the following:
- [x] Code changes are compact and well-structured to facilitate easy review
- [ ] Changes are documented in the README.md and other relevant documentation pages
- [x] PR title and description accurately reflect the changes and are detailed enough for historical tracking
- [ ] PR contains tests that cover all new code and the code has been manual tested
- [x] All new dependencies are declared (if any), and no unnecessary libraries are added
- [x] Performance impacts (if any) of the changes are evaluated and documented
- [x] Security implications of the changes (if any) are reviewed and addressed
- [x] I have read the [Contributing Guidelines](../CONTRIBUTING.md) and agree to follow the [Code of Conduct](../CODE_OF_CONDUCT.md)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
